### PR TITLE
feat(sitemap): Add a new configuration to discard invalid patterns from sitemap and avoid duplicate content

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,16 @@ To see all the types you can choose from, run `strapi content-types:list`.
 
 > `required:` NO | `type:` array
 
+### Exclude invalid relations relational objects
+This setting allow you to exclude invalid entries when the pattern is not valid for the entry
+
+Example : You have added a `slug` property to the configuration entry `allowedFields`.
+If a content doesn't have the field `slug` filled, no entry in the sitemap will be generated for this content (to avoid duplicate content)
+
+###### Key: `discardInvalidRelations `
+
+> `required:` NO | `type:` boolean
+
 ## 🤝 Contributing
 
 Feel free to fork and make a pull request of this plugin. All the input is welcome!

--- a/server/config.js
+++ b/server/config.js
@@ -8,6 +8,7 @@ module.exports = {
     autoGenerate: false,
     caching: true,
     allowedFields: ['id', 'uid'],
+    discardInvalidRelations: false,
     excludedTypes: [
       'admin::permission',
       'admin::role',

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -28,6 +28,13 @@ global.strapi = {
       },
     },
   },
+  config: {
+    plugin: {
+      sitemap: {
+        discardInvalidRelations: false
+      }
+    }
+  }
 };
 
 describe('Pattern service', () => {

--- a/server/services/__tests__/pattern.test.js
+++ b/server/services/__tests__/pattern.test.js
@@ -3,6 +3,18 @@
 
 const patternService = require('../pattern');
 
+const get = function baseGet(object, path) {
+  let index = 0;
+  path = path.split('.');
+  const length = path.length;
+
+  while (object != null && index < length) {
+    const newKey = path[index++];
+    object = object[newKey];
+  }
+  return (index && index === length) ? object : undefined;
+};
+
 global.strapi = {
   contentTypes: {
     'another-test-relation:target:api': {
@@ -33,7 +45,8 @@ global.strapi = {
       sitemap: {
         discardInvalidRelations: false
       }
-    }
+    },
+    get: ((key) => get(global.strapi.config, key)),
   }
 };
 
@@ -157,6 +170,22 @@ describe('Pattern service', () => {
       const result = await patternService().resolvePattern(pattern, entity);
 
       expect(result).toMatch('/en/my-page-slug');
+    });
+
+    test('Resolve pattern with missing relation', async () => {
+      const pattern = '/en/[slug]';
+      const entity = {
+        title: "my-page-title",
+      };
+
+      global.strapi.config.plugin.sitemap.discardInvalidRelations = true;
+
+      const result = await patternService().resolvePattern(pattern, entity);
+
+      expect(result).toBe(null);
+
+      // Restore 
+      global.strapi.config.plugin.sitemap.discardInvalidRelations = false;
     });
   });
   describe('Validate pattern', () => {

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -67,6 +67,7 @@ const getLanguageLinks = async (config, page, contentType, defaultURL) => {
 
     const { pattern } = config.contentTypes[contentType]['languages'][locale];
     const translationUrl = await strapi.plugins.sitemap.services.pattern.resolvePattern(pattern, translation);
+    if (!translationUrl) return null;
     let hostnameOverride = config.hostname_overrides[translation.locale] || '';
     hostnameOverride = hostnameOverride.replace(/\/+$/, '');
     links.push({
@@ -112,6 +113,7 @@ const getSitemapPageData = async (config, page, contentType) => {
 
   const { pattern } = config.contentTypes[contentType]['languages'][locale];
   const path = await strapi.plugins.sitemap.services.pattern.resolvePattern(pattern, page);
+  if (!path) return null;
   let hostnameOverride = config.hostname_overrides[page.locale] || '';
   hostnameOverride = hostnameOverride.replace(/\/+$/, '');
   const url = `${hostnameOverride}${path}`;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

fix #175 

### What does it do?

Introduce a new configuration to discard invalid replacement pattern

### Why is it needed?

It creates duplicate content if the field is not mandatory

### How to test it?

1. Add a "slug" field to allowedFields
2. Create a content in which you dont fill the "slug" property in Strapi (for whatever reason)
3. Generate the sitemap
4. The sitemap generate multiple entries with the same url because of empty slugs
