### PR TITLE
fix: add check for missing or invalid URL creating a sitemap stream

### DIFF
--- a/server/services/core.js
+++ b/server/services/core.js
@@ -243,16 +243,6 @@ const getSitemapStream = async (urlCount) => {
     xslObj.xslUrl = 'xsl/sitemap.xsl';
   }
 
-  if (!config.hostname) {
-    strapi.log.info(logMessage('No sitemap XML was generated because there was no hostname configured.'));
-    return;
-  }
-
-  if (!isValidUrl(config.hostname)) {
-    strapi.log.info(logMessage('No sitemap XML was generated because the hostname was invalid'));
-    return;
-  }
-
   if (urlCount <= LIMIT) {
     return [new SitemapStream({
       hostname: config.hostname,
@@ -297,6 +287,7 @@ const getSitemapStream = async (urlCount) => {
  * @returns {void}
  */
 const createSitemap = async (cache, invalidationObject) => {
+  const config = await getService('settings').getConfig();
   const cachingEnabled = strapi.config.get('plugin.sitemap.caching');
   const autoGenerationEnabled = strapi.config.get('plugin.sitemap.autoGenerate');
 
@@ -314,7 +305,17 @@ const createSitemap = async (cache, invalidationObject) => {
     ];
 
     if (isEmpty(allEntries)) {
-      strapi.log.info(logMessage('No sitemap XML was generated because there were 0 URLs configured.'));
+      strapi.log.warn(logMessage('No sitemap XML was generated because there were 0 URLs configured.'));
+      return;
+    }
+
+    if (!config.hostname) {
+      strapi.log.warn(logMessage('No sitemap XML was generated because there was no hostname configured.'));
+      return;
+    }
+
+    if (!isValidUrl(config.hostname)) {
+      strapi.log.warn(logMessage('No sitemap XML was generated because the hostname was invalid'));
       return;
     }
 

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -8,7 +8,7 @@ const { getConfigUrls } = require('@strapi/utils');
 const { SitemapStream, streamToPromise, SitemapAndIndexStream } = require('sitemap');
 const { isEmpty } = require('lodash');
 
-const { logMessage, getService, formatCache, mergeCache } = require('../utils');
+const { logMessage, getService, formatCache, mergeCache, isValidUrl } = require('../utils');
 
 /**
  * Add link x-default url to url bundles from strapi i18n plugin default locale.
@@ -241,6 +241,16 @@ const getSitemapStream = async (urlCount) => {
 
   if (enableXsl) {
     xslObj.xslUrl = 'xsl/sitemap.xsl';
+  }
+
+  if (!config.hostname) {
+    strapi.log.info(logMessage('No sitemap XML was generated because there was no hostname configured.'));
+    return;
+  }
+
+  if (!isValidUrl(config.hostname)) {
+    strapi.log.info(logMessage('No sitemap XML was generated because the hostname was invalid'));
+    return;
   }
 
   if (urlCount <= LIMIT) {

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -71,6 +71,17 @@ const mergeCache = (oldCache, newCache) => {
   return mergedCache;
 };
 
+
+const isValidUrl = (url) => {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(!url);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
 module.exports = {
   getService,
   getCoreStore,
@@ -78,4 +89,5 @@ module.exports = {
   noLimit,
   formatCache,
   mergeCache,
+  isValidUrl,
 };

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -75,7 +75,7 @@ const mergeCache = (oldCache, newCache) => {
 const isValidUrl = (url) => {
   try {
     // eslint-disable-next-line no-new
-    new URL(!url);
+    new URL(url);
     return true;
   } catch (err) {
     return false;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

### What does it do?

Add two checks for a missing or invalid hostname before initiating the SitemapStream.

### Why is it needed?

To solve #174 
